### PR TITLE
Replace `last_comment` with `last_description`

### DIFF
--- a/lib/eslintrb/eslinttask.rb
+++ b/lib/eslintrb/eslinttask.rb
@@ -52,7 +52,7 @@ module Eslintrb
     def define # :nodoc:
 
       actual_name = Hash === name ? name.keys.first : name
-      unless ::Rake.application.last_comment
+      unless ::Rake.application.last_description
         desc "Run ESLint"
       end
       task name do


### PR DESCRIPTION
```bash
$ rake eslint
[DEPRECATION] `last_comment` is deprecated.  Please use `last_description` instead.
```
This is causing a failure in Heroku deploys.